### PR TITLE
SN100x/halimpl/libnxpparser: Guard with soong namespace

### DIFF
--- a/SN100x/halimpl/libnxpparser/Android.bp
+++ b/SN100x/halimpl/libnxpparser/Android.bp
@@ -1,3 +1,6 @@
+soong_namespace {
+}
+
 cc_library_shared {
 
     name: "nxp_nci_parser",


### PR DESCRIPTION
* nxp_nci_parser already defined by hardware/nxp/nfc/snxxx/halimpl/libnxpparser.

Change-Id: Iac6a4ff085ca0deb47de318c5742b3ba41f8a70d